### PR TITLE
Handle configuration option for file transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   },
   "dependencies": {
     "airbrake": "~> 1.2",
+    "coffee-script": "~> 1.9.2",
+    "ramda": "^0.22.1",
     "winston": "^2.2.0",
-    "winston-airbrake": "0.1.0",
-    "coffee-script": "~> 1.9.2"
+    "winston-airbrake": "0.1.0"
   },
   "devDependencies": {
     "chai": "~> 3.5.0",

--- a/test/airbrake_init_test.coffee
+++ b/test/airbrake_init_test.coffee
@@ -57,6 +57,7 @@ describe 'airbrake_init', ->
     describe 'filters', ->
       airbrake = null
       environment = memo().is -> null
+      fileTransformation = memo().is -> null
 
       beforeEach ->
         configKeys =
@@ -64,6 +65,7 @@ describe 'airbrake_init', ->
           'apiKey': 'myAirbrakeId'
           'whiteListKeys': ['keys']
           'developmentEnvironments': ['dev', 'staging']
+          'fileTransformation': fileTransformation()
           'env': environment()
         airbrake = AirbrakeInit.initAirbrake(configKeys)
 
@@ -94,6 +96,34 @@ describe 'airbrake_init', ->
             filteredNotice = filter(notice)
             expect(filteredNotice).not.to.be.null
             expect(filteredNotice.context).to.eql(notice.context)
+
+
+          context 'file transformation', ->
+            fileTransformation.is -> {
+              pattern: /abc/,
+              replacement: 'def'
+            }
+
+            initialFile = 'abcd'
+            transformedFile = 'defd'
+
+            it 'transforms file', ->
+              notice = {
+                errors: [
+                  {
+                    backtrace: [
+                      {
+                        file: initialFile
+                      }
+                    ]
+                  }
+                ],
+                context : {
+                  environment: environment()
+                }
+              }
+              filteredNotice = filter(notice)
+              expect(filteredNotice.errors[0].backtrace[0].file).to.eql(transformedFile)
 
     describe 'whitelist', ->
       beforeEach ->


### PR DESCRIPTION
Alternative and better solution of EN-787. Messages in airbrake are not grouping although they have the same error message. The reason is that they differ in file name. For example one error can have file as `assets.salemove.com/assets/operator_app-1234abc.js:61` and the other one (which is the same error) can have `assets.salemove.com/assets/operator_app-5678def.js:61`. This commit removes hashes from these strings (in backtrace of the error) so that they will be grouped together.
See also discussion in https://github.com/salemove/message-hub/pull/421