### PR TITLE
Upgrade dependencies

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -1,0 +1,7 @@
+[
+  {
+    "component": "sync-exec",
+    "version" : "0.6.2",
+    "justification": "Medium. Package seems unmaintained, no fix available."
+  }
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 before_script:
   - npm install
+node_js:
+  - 10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbrake-init",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Helps to create node-airbrake and winston-airbrake instances",
   "main": "lib/airbrake_init",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "test": "test"
   },
   "dependencies": {
-    "airbrake": "~> 2.0",
-    "coffee-script": "~> 1.12",
-    "ramda": "~> 0.24"
+    "airbrake": "~> 2.1",
+    "coffeescript": "~> 2.4",
+    "ramda": "~> 0.26"
   },
   "devDependencies": {
     "chai": "~> 3.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Helps to create node-airbrake and winston-airbrake instances",
   "main": "lib/airbrake_init",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "security-scan": "retire --package --node"
   },
   "repository": {
     "type": "git",
@@ -32,7 +33,8 @@
     "chai": "~> 3.5.0",
     "expect": "^1.14.0",
     "memo-is": "0.0.2",
-    "mocha": "~> 2.4.5",
+    "mocha": "~> 5.1.0",
+    "retire": "^2.0.3",
     "should": "^11.1.0",
     "winston": "^2.2.0",
     "winston-airbrake": "1.0.0"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require should
 --reporter spec
 --ui bdd
---compilers coffee:coffee-script/register
+--compilers coffee:coffeescript/register


### PR DESCRIPTION
[INF-2038](https://salemove.atlassian.net/browse/INF-2038)

`kluster-proxy` building fails with security vulnerabilities. They have been temporarily ignored (https://github.com/salemove/kluster-proxy/pull/30), these changes upgrade dependencies to eliminate the vulnerabilities.